### PR TITLE
Improve find_or_create_by documentation to include caveats on usage within repeatable read transactions

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -200,6 +200,9 @@ module ActiveRecord
     #   the problem of running out of integers, if the underlying table is still stuck on a primary
     #   key of type int (note: All Rails apps since 5.1+ have defaulted to bigint, which is not liable
     #   to this problem).
+    # * This method does not work as expected if used within an existing 'repetable read' transaction. 
+    #   The isolation level prevents it from returning a record that was created after the transaction started.
+    #   In that case, it'll raise an <tt>ActiveRecord::RecordNotFound</tt> exception.
     #
     # This method will return a record if all given attributes are covered by unique constraints
     # (unless the INSERT -> DELETE -> SELECT race condition is triggered), but if creation was attempted


### PR DESCRIPTION
This change is in response to: https://github.com/rails/rails/issues/39691.
I only spent a minute thinking about the copy. Suggestions are welcomed :-)